### PR TITLE
add UMD header to support AMD loaders as well

### DIFF
--- a/dist/ngecharts.js
+++ b/dist/ngecharts.js
@@ -1,5 +1,20 @@
-const angular = require('./node_modules/angular/angular.min.js');
-const echarts = require('./node_modules/echarts/dist/echarts.min');
+(function (root, factory) {
+    if (typeof require === 'function' && typeof exports === 'object') {
+        // CommonJS
+        var angular = require('./node_modules/angular/angular.min.js');
+        var echarts = require('./node_modules/echarts/dist/echarts.min');
+
+        exports.ngecharts = factory(angular, echarts);
+    } else if (typeof define === 'function' && define.amd) {
+        // AMD.
+        define(['angular', 'echarts'], function (angular, echarts) {
+            return root.ngecharts = factory(angular, echarts);
+        });
+    } else {
+        // Browser globals
+        root.ngecharts = factory(root.angular, root.echarts);
+    }
+}(this, function (angular, echarts) {
 
 var app = angular.module('ngecharts', []);
 
@@ -39,4 +54,4 @@ function buildLinkFunc($window) {
         })
     };
 }
-
+}));


### PR DESCRIPTION
Hi,

thanks for publishing this on npm. I just wanted to make a minor addition by adding an UMD header to also support AMD type module loaders. Otherwise it doesn't work in our application.

Also I changed `const` to `var` to support non-ES6 environments.

I left these two rows unchanged in order to not break your environment.

```javascript
var angular = require('./node_modules/angular/angular.min.js');
var echarts = require('./node_modules/echarts/dist/echarts.min');
```

However, referencing full paths like `node_modules/.../..` isn't ideal. You should rather just require them like `require('angular')`.

It would be cool if you could merge these changes in and update it on npm :smile:. 
Thx :+1: 